### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,6 @@
 name: Rust
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/seahal/umaxica-app-client/security/code-scanning/2](https://github.com/seahal/umaxica-app-client/security/code-scanning/2)

The best way to fix this problem is to add a `permissions` block to the workflow file, specifying only the minimum required permissions. Since the workflow only builds and tests the Rust code, and does not require writing to the repository or interacting with pull requests/issues, the minimal safe permission is `contents: read`. This can be set at the workflow level (top-level, applying to all jobs) or at a job level (under each job). Setting it at the top-level is more maintainable and future-proof.  
Change required: Insert a `permissions: contents: read` block immediately after the `name:` and before `on:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
